### PR TITLE
remove out of date copy statement

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,6 @@ ARG USER_UID
 ARG USER_GID
 
 COPY --from=dep-compile /opt/$USERNAME/install /opt/$USERNAME/install
-COPY launch/ /opt/lc/launch_files/
 
 WORKDIR /
 


### PR DESCRIPTION
`/launch ` directory was moved and no longer requires to be copied with `COPY` in dockerfile